### PR TITLE
Add more information about the required token scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ noisetor                 1             SuperQ
 
 ## Dependencies
 
-A `GITHUB_TOKEN` environment variable is required to access the GitHub API.
+Generate a Personal Access Token at [https://github.com/settings/tokens](https://github.com/settings/tokens) which needs the `read:org` scope. Use this token as `GITHUB_TOKEN` environment variable, which is required to access the GitHub API.


### PR DESCRIPTION
Signed-off-by: Wiard van Rij <wiard@outlook.com>

It gave me 
```
GET https://api.github.com/user/orgs: 403 You need at least read:org scope or user scope to list your organizations. []
```
Which is fixed by adding the `read:org` scope to the Token.

Cheers for making this btw :) Really cool!